### PR TITLE
File icicle tree 구현 

### DIFF
--- a/icicle/taejs/index.html
+++ b/icicle/taejs/index.html
@@ -6,7 +6,7 @@
     <title>Icicle Tutorial</title>
   </head>
   <body>
-    <div id="chart"></div>
+    <svg id="icicle"></svg>
     <script type="module" src="/src/main.ts"></script>
   </body>
 </html>

--- a/icicle/taejs/package-lock.json
+++ b/icicle/taejs/package-lock.json
@@ -1,15 +1,664 @@
 {
-  "name": "taejs",
+  "name": "githru-tutorial-icicle-taejs",
   "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "taejs",
+      "name": "githru-tutorial-icicle-taejs",
       "version": "0.0.0",
+      "dependencies": {
+        "d3": "^7.6.1"
+      },
       "devDependencies": {
+        "@types/d3": "^7.4.0",
         "typescript": "^4.6.4",
         "vite": "^3.0.0"
+      }
+    },
+    "node_modules/@types/d3": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.0.tgz",
+      "integrity": "sha512-jIfNVK0ZlxcuRDKtRS/SypEyOQ6UHaFQBKv032X45VvxSJ6Yi5G9behy9h6tNTHTDGh5Vq+KbmBjUWLgY4meCA==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.3.tgz",
+      "integrity": "sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ==",
+      "dev": true
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.1.tgz",
+      "integrity": "sha512-zji/iIbdd49g9WN0aIsGcwcTBUkgLsCSwB+uH+LPVDAiKWENMtI3cJEWt+7/YYwelMoZmbBfzA3qCdrZ2XFNnw==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.1.tgz",
+      "integrity": "sha512-B532DozsiTuQMHu2YChdZU0qsFJSio3Q6jmBYGYNp3gMDzBmuFFgPt9qKA4VYuLZMp4qc6eX7IUFUEsvHiXZAw==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-eQfcxIHrg7V++W8Qxn6QkqBNBokyhdWSAS73AbkbMzvLQmVVBviknoz2SRS/ZJdIOmhcmmdCRE/NFOm28Z1AMw==",
+      "dev": true
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==",
+      "dev": true
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.1.tgz",
+      "integrity": "sha512-C3zfBrhHZvrpAAK3YXqLWVAGo87A4SvJ83Q/zVJ8rFWJdKejUnDYaWZPkA8K84kb2vDA/g90LTQAz7etXcgoQQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.1.tgz",
+      "integrity": "sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ==",
+      "dev": true
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-NhxMn3bAkqhjoxabVJWKryhnZXXYYVQxaBnbANu0O94+O/nX9qSjrA1P1jbAQJxJf+VC72TxDX/YJcKue5bRqw==",
+      "dev": true
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.1.tgz",
+      "integrity": "sha512-o1Va7bLwwk6h03+nSM8dpaGEYnoIG19P0lKqlic8Un36ymh9NSkNFX1yiXMKNMx8rJ0Kfnn2eovuFaL6Jvj0zA==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.0.tgz",
+      "integrity": "sha512-o0/7RlMl9p5n6FQDptuJVMxDf/7EDEv2SYEO/CwdG2tr1hTfUVi0Iavkk2ax+VpaQ/1jVhpnj5rq1nj8vwhn2A==",
+      "dev": true
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
+      "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA==",
+      "dev": true
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-toZJNOwrOIqz7Oh6Q7l2zkaNfXkfR7mFSJvGvlD/Ciq/+SQ39d5gynHJZ/0fjt83ec3WL7+u3ssqIijQtBISsw==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.3.tgz",
+      "integrity": "sha512-z8GteGVfkWJMKsx6hwC3SiTSLspL98VNpmvLpEFJQpZPq6xpA1I8HNBDNSpukfK0Vb0l64zGFhzunLgEAcBWSA==",
+      "dev": true
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
+      "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==",
+      "dev": true
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.0.2.tgz",
+      "integrity": "sha512-DbqK7MLYA8LpyHQfv6Klz0426bQEf7bRTvhMy44sNGVyZoWn//B0c+Qbeg8Osi2Obdc9BLLXYAKpyWege2/7LQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.0.tgz",
+      "integrity": "sha512-g+sey7qrCa3UbsQlMZZBOHROkFqx7KZKvUpRzI/tAp/8erZWpYq7FgNKvYwebi2LaEiVs1klhUfd3WCThxmmWQ==",
+      "dev": true
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.0.tgz",
+      "integrity": "sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg==",
+      "dev": true
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.0.tgz",
+      "integrity": "sha512-D49z4DyzTKXM0sGKVqiTDTYr+DHg/uxsiWDAkNrwXYuiZVd9o9wXZIo+YsHkifOiyBkmSWlEngHCQme54/hnHw==",
+      "dev": true
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.2.tgz",
+      "integrity": "sha512-QNcK8Jguvc8lU+4OfeNx+qnVy7c0VrDJ+CCVFS9srBo2GL9Y18CnIxBdTF3v38flrGy5s1YggcoAiu6s4fLQIw==",
+      "dev": true
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-IIE6YTekGczpLYo/HehAy3JGF1ty7+usI97LqraNa8IiDur+L44d0VOjAvFQWJVdZOJHukUJw+ZdZBlgeUsHOQ==",
+      "dev": true
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+      "integrity": "sha512-dsoJGEIShosKVRBZB0Vo3C8nqSDqVGujJU6tPznsBJxNJNwMF8utmS83nvCBKQYPpjCzaaHcrf66iTRpZosLPw==",
+      "dev": true
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.3.tgz",
+      "integrity": "sha512-Mw5cf6nlW1MlefpD9zrshZ+DAWL4IQ5LnWfRheW6xwsdaWOb6IRRu2H7XPAQcyXEx1D7XQWgdoKR83ui1/HlEA==",
+      "dev": true
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.0.tgz",
+      "integrity": "sha512-jYIYxFFA9vrJ8Hd4Se83YI6XF+gzDL1aC5DCsldai4XYYiVNdhtpGbA/GM6iyQ8ayhSp3a148LY34hy7A4TxZA==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
+      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==",
+      "dev": true
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.0.tgz",
+      "integrity": "sha512-yjfBUe6DJBsDin2BMIulhSHmr5qNR5Pxs17+oW4DoVPyVIXZ+m6bs7j1UVKP08Emv6jRmYrYqxYzO63mQxy1rw==",
+      "dev": true
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
+      "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g==",
+      "dev": true
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-Sv4qEI9uq3bnZwlOANvYK853zvpdKEm1yz9rcc8ZTsxvRklcs9Fx4YFuGA3gXoQN/c/1T6QkVNjhaRO/cWj94g==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.1.tgz",
+      "integrity": "sha512-7s5L9TjfqIYQmQQEUcpMAcBOahem7TRoSO/+Gkz02GbMVuULiZzjF2BOdw291dbO2aNon4m2OdFsRGaCq2caLQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
+      "dev": true
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/d3": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.6.1.tgz",
+      "integrity": "sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
+      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.0.tgz",
+      "integrity": "sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
+      "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.0.1.tgz",
+      "integrity": "sha512-Wt23xBych5tSy9IYAM1FR2rWIBFWa52B/oF/GYe5zbdHrg08FU8+BuI6X4PvTwPDdqdAdq04fuWJpELtsaEjeA==",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.0.1.tgz",
+      "integrity": "sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+      "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.1.0.tgz",
+      "integrity": "sha512-tGDh1Muf8kWjEDT/LswZJ8WF85yDZLvVJpYU9Nq+8+yW1Z5enxrmXOhTArlkaElU+CTn0OTVNli+/i+HP45QEQ==",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.0.0.tgz",
+      "integrity": "sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
+      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
+      "dependencies": {
+        "robust-predicates": "^3.0.0"
       }
     },
     "node_modules/esbuild": {
@@ -399,6 +1048,25 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/is-core-module": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
@@ -476,6 +1144,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
+      "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g=="
+    },
     "node_modules/rollup": {
       "version": "2.77.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.0.tgz",
@@ -490,6 +1163,16 @@
       "optionalDependencies": {
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/source-map-js": {
       "version": "1.0.2",
@@ -568,6 +1251,541 @@
     }
   },
   "dependencies": {
+    "@types/d3": {
+      "version": "7.4.0",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.0.tgz",
+      "integrity": "sha512-jIfNVK0ZlxcuRDKtRS/SypEyOQ6UHaFQBKv032X45VvxSJ6Yi5G9behy9h6tNTHTDGh5Vq+KbmBjUWLgY4meCA==",
+      "dev": true,
+      "requires": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "@types/d3-array": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.0.3.tgz",
+      "integrity": "sha512-Reoy+pKnvsksN0lQUlcH6dOGjRZ/3WRwXR//m+/8lt1BXeI4xyaUZoqULNjyXXRuh0Mj4LNpkCvhUpQlY3X5xQ==",
+      "dev": true
+    },
+    "@types/d3-axis": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.1.tgz",
+      "integrity": "sha512-zji/iIbdd49g9WN0aIsGcwcTBUkgLsCSwB+uH+LPVDAiKWENMtI3cJEWt+7/YYwelMoZmbBfzA3qCdrZ2XFNnw==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-brush": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.1.tgz",
+      "integrity": "sha512-B532DozsiTuQMHu2YChdZU0qsFJSio3Q6jmBYGYNp3gMDzBmuFFgPt9qKA4VYuLZMp4qc6eX7IUFUEsvHiXZAw==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-eQfcxIHrg7V++W8Qxn6QkqBNBokyhdWSAS73AbkbMzvLQmVVBviknoz2SRS/ZJdIOmhcmmdCRE/NFOm28Z1AMw==",
+      "dev": true
+    },
+    "@types/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-HKuicPHJuvPgCD+np6Se9MQvS6OCbJmOjGvylzMJRlDwUXjKTTXs6Pwgk79O09Vj/ho3u1ofXnhFOaEWWPrlwA==",
+      "dev": true
+    },
+    "@types/d3-contour": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.1.tgz",
+      "integrity": "sha512-C3zfBrhHZvrpAAK3YXqLWVAGo87A4SvJ83Q/zVJ8rFWJdKejUnDYaWZPkA8K84kb2vDA/g90LTQAz7etXcgoQQ==",
+      "dev": true,
+      "requires": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "@types/d3-delaunay": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.1.tgz",
+      "integrity": "sha512-tLxQ2sfT0p6sxdG75c6f/ekqxjyYR0+LwPrsO1mbC9YDBzPJhs2HbJJRrn8Ez1DBoHRo2yx7YEATI+8V1nGMnQ==",
+      "dev": true
+    },
+    "@types/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-NhxMn3bAkqhjoxabVJWKryhnZXXYYVQxaBnbANu0O94+O/nX9qSjrA1P1jbAQJxJf+VC72TxDX/YJcKue5bRqw==",
+      "dev": true
+    },
+    "@types/d3-drag": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.1.tgz",
+      "integrity": "sha512-o1Va7bLwwk6h03+nSM8dpaGEYnoIG19P0lKqlic8Un36ymh9NSkNFX1yiXMKNMx8rJ0Kfnn2eovuFaL6Jvj0zA==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-dsv": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.0.tgz",
+      "integrity": "sha512-o0/7RlMl9p5n6FQDptuJVMxDf/7EDEv2SYEO/CwdG2tr1hTfUVi0Iavkk2ax+VpaQ/1jVhpnj5rq1nj8vwhn2A==",
+      "dev": true
+    },
+    "@types/d3-ease": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.0.tgz",
+      "integrity": "sha512-aMo4eaAOijJjA6uU+GIeW018dvy9+oH5Y2VPPzjjfxevvGQ/oRDs+tfYC9b50Q4BygRR8yE2QCLsrT0WtAVseA==",
+      "dev": true
+    },
+    "@types/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-toZJNOwrOIqz7Oh6Q7l2zkaNfXkfR7mFSJvGvlD/Ciq/+SQ39d5gynHJZ/0fjt83ec3WL7+u3ssqIijQtBISsw==",
+      "dev": true,
+      "requires": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "@types/d3-force": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.3.tgz",
+      "integrity": "sha512-z8GteGVfkWJMKsx6hwC3SiTSLspL98VNpmvLpEFJQpZPq6xpA1I8HNBDNSpukfK0Vb0l64zGFhzunLgEAcBWSA==",
+      "dev": true
+    },
+    "@types/d3-format": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.1.tgz",
+      "integrity": "sha512-5KY70ifCCzorkLuIkDe0Z9YTf9RR2CjBX1iaJG+rgM/cPP+sO+q9YdQ9WdhQcgPj1EQiJ2/0+yUkkziTG6Lubg==",
+      "dev": true
+    },
+    "@types/d3-geo": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.0.2.tgz",
+      "integrity": "sha512-DbqK7MLYA8LpyHQfv6Klz0426bQEf7bRTvhMy44sNGVyZoWn//B0c+Qbeg8Osi2Obdc9BLLXYAKpyWege2/7LQ==",
+      "dev": true,
+      "requires": {
+        "@types/geojson": "*"
+      }
+    },
+    "@types/d3-hierarchy": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.0.tgz",
+      "integrity": "sha512-g+sey7qrCa3UbsQlMZZBOHROkFqx7KZKvUpRzI/tAp/8erZWpYq7FgNKvYwebi2LaEiVs1klhUfd3WCThxmmWQ==",
+      "dev": true
+    },
+    "@types/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-jx5leotSeac3jr0RePOH1KdR9rISG91QIE4Q2PYTu4OymLTZfA3SrnURSLzKH48HmXVUru50b8nje4E79oQSQw==",
+      "dev": true,
+      "requires": {
+        "@types/d3-color": "*"
+      }
+    },
+    "@types/d3-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.0.0.tgz",
+      "integrity": "sha512-0g/A+mZXgFkQxN3HniRDbXMN79K3CdTpLsevj+PXiTcb2hVyvkZUBg37StmgCQkaD84cUJ4uaDAWq7UJOQy2Tg==",
+      "dev": true
+    },
+    "@types/d3-polygon": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.0.tgz",
+      "integrity": "sha512-D49z4DyzTKXM0sGKVqiTDTYr+DHg/uxsiWDAkNrwXYuiZVd9o9wXZIo+YsHkifOiyBkmSWlEngHCQme54/hnHw==",
+      "dev": true
+    },
+    "@types/d3-quadtree": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.2.tgz",
+      "integrity": "sha512-QNcK8Jguvc8lU+4OfeNx+qnVy7c0VrDJ+CCVFS9srBo2GL9Y18CnIxBdTF3v38flrGy5s1YggcoAiu6s4fLQIw==",
+      "dev": true
+    },
+    "@types/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-IIE6YTekGczpLYo/HehAy3JGF1ty7+usI97LqraNa8IiDur+L44d0VOjAvFQWJVdZOJHukUJw+ZdZBlgeUsHOQ==",
+      "dev": true
+    },
+    "@types/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-Yk4htunhPAwN0XGlIwArRomOjdoBFXC3+kCxK2Ubg7I9shQlVSJy/pG/Ht5ASN+gdMIalpk8TJ5xV74jFsetLA==",
+      "dev": true,
+      "requires": {
+        "@types/d3-time": "*"
+      }
+    },
+    "@types/d3-scale-chromatic": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+      "integrity": "sha512-dsoJGEIShosKVRBZB0Vo3C8nqSDqVGujJU6tPznsBJxNJNwMF8utmS83nvCBKQYPpjCzaaHcrf66iTRpZosLPw==",
+      "dev": true
+    },
+    "@types/d3-selection": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.3.tgz",
+      "integrity": "sha512-Mw5cf6nlW1MlefpD9zrshZ+DAWL4IQ5LnWfRheW6xwsdaWOb6IRRu2H7XPAQcyXEx1D7XQWgdoKR83ui1/HlEA==",
+      "dev": true
+    },
+    "@types/d3-shape": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.0.tgz",
+      "integrity": "sha512-jYIYxFFA9vrJ8Hd4Se83YI6XF+gzDL1aC5DCsldai4XYYiVNdhtpGbA/GM6iyQ8ayhSp3a148LY34hy7A4TxZA==",
+      "dev": true,
+      "requires": {
+        "@types/d3-path": "*"
+      }
+    },
+    "@types/d3-time": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.0.tgz",
+      "integrity": "sha512-sZLCdHvBUcNby1cB6Fd3ZBrABbjz3v1Vm90nysCQ6Vt7vd6e/h9Lt7SiJUoEX0l4Dzc7P5llKyhqSi1ycSf1Hg==",
+      "dev": true
+    },
+    "@types/d3-time-format": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.0.tgz",
+      "integrity": "sha512-yjfBUe6DJBsDin2BMIulhSHmr5qNR5Pxs17+oW4DoVPyVIXZ+m6bs7j1UVKP08Emv6jRmYrYqxYzO63mQxy1rw==",
+      "dev": true
+    },
+    "@types/d3-timer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.0.tgz",
+      "integrity": "sha512-HNB/9GHqu7Fo8AQiugyJbv6ZxYz58wef0esl4Mv828w1ZKpAshw/uFWVDUcIB9KKFeFKoxS3cHY07FFgtTRZ1g==",
+      "dev": true
+    },
+    "@types/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-Sv4qEI9uq3bnZwlOANvYK853zvpdKEm1yz9rcc8ZTsxvRklcs9Fx4YFuGA3gXoQN/c/1T6QkVNjhaRO/cWj94g==",
+      "dev": true,
+      "requires": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/d3-zoom": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.1.tgz",
+      "integrity": "sha512-7s5L9TjfqIYQmQQEUcpMAcBOahem7TRoSO/+Gkz02GbMVuULiZzjF2BOdw291dbO2aNon4m2OdFsRGaCq2caLQ==",
+      "dev": true,
+      "requires": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "@types/geojson": {
+      "version": "7946.0.10",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.10.tgz",
+      "integrity": "sha512-Nmh0K3iWQJzniTuPRcJn5hxXkfB1T1pgB89SBig5PlJQU5yocazeu4jATJlaA0GYFKWMqDdvYemoSnF2pXgLVA==",
+      "dev": true
+    },
+    "commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw=="
+    },
+    "d3": {
+      "version": "7.6.1",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.6.1.tgz",
+      "integrity": "sha512-txMTdIHFbcpLx+8a0IFhZsbp+PfBBPt8yfbmukZTQFroKuFqIwqswF0qE5JXWefylaAVpSXFoKm3yP+jpNLFLw==",
+      "requires": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      }
+    },
+    "d3-array": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.0.tgz",
+      "integrity": "sha512-3yXFQo0oG3QCxbF06rMPFyGRMGJNS7NvsV1+2joOjbBE+9xvWQ8+GcMJAjRCzw06zQ3/arXeJgbPYcjUCuC+3g==",
+      "requires": {
+        "internmap": "1 - 2"
+      }
+    },
+    "d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw=="
+    },
+    "d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "requires": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      }
+    },
+    "d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "requires": {
+        "d3-path": "1 - 3"
+      }
+    },
+    "d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="
+    },
+    "d3-contour": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.0.tgz",
+      "integrity": "sha512-7aQo0QHUTu/Ko3cP9YK9yUTxtoDEiDGwnBHyLxG5M4vqlBkO/uixMRele3nfsfj6UXOcuReVpVXzAboGraYIJw==",
+      "requires": {
+        "d3-array": "^3.2.0"
+      }
+    },
+    "d3-delaunay": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.2.tgz",
+      "integrity": "sha512-IMLNldruDQScrcfT+MWnazhHbDJhcRJyOEBAJfwQnHle1RPh6WDuLvxNArUju2VSMSUuKlY5BGHRJ2cYyoFLQQ==",
+      "requires": {
+        "delaunator": "5"
+      }
+    },
+    "d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg=="
+    },
+    "d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "requires": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      }
+    },
+    "d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "requires": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      }
+    },
+    "d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="
+    },
+    "d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "requires": {
+        "d3-dsv": "1 - 3"
+      }
+    },
+    "d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "requires": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      }
+    },
+    "d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA=="
+    },
+    "d3-geo": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.0.1.tgz",
+      "integrity": "sha512-Wt23xBych5tSy9IYAM1FR2rWIBFWa52B/oF/GYe5zbdHrg08FU8+BuI6X4PvTwPDdqdAdq04fuWJpELtsaEjeA==",
+      "requires": {
+        "d3-array": "2.5.0 - 3"
+      }
+    },
+    "d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA=="
+    },
+    "d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "requires": {
+        "d3-color": "1 - 3"
+      }
+    },
+    "d3-path": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.0.1.tgz",
+      "integrity": "sha512-gq6gZom9AFZby0YLduxT1qmrp4xpBA1YZr19OI717WIdKE2OM5ETq5qrHLb301IgxhLwcuxvGZVLeeWc/k1I6w=="
+    },
+    "d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg=="
+    },
+    "d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw=="
+    },
+    "d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ=="
+    },
+    "d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "requires": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      }
+    },
+    "d3-scale-chromatic": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.0.0.tgz",
+      "integrity": "sha512-Lx9thtxAKrO2Pq6OO2Ua474opeziKr279P/TKZsMAhYyNDD3EnCffdbgeSYN5O7m2ByQsxtuP2CSDczNUIZ22g==",
+      "requires": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      }
+    },
+    "d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
+    },
+    "d3-shape": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.1.0.tgz",
+      "integrity": "sha512-tGDh1Muf8kWjEDT/LswZJ8WF85yDZLvVJpYU9Nq+8+yW1Z5enxrmXOhTArlkaElU+CTn0OTVNli+/i+HP45QEQ==",
+      "requires": {
+        "d3-path": "1 - 3"
+      }
+    },
+    "d3-time": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.0.0.tgz",
+      "integrity": "sha512-zmV3lRnlaLI08y9IMRXSDshQb5Nj77smnfpnd2LrBa/2K281Jijactokeak14QacHs/kKq0AQ121nidNYlarbQ==",
+      "requires": {
+        "d3-array": "2 - 3"
+      }
+    },
+    "d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "requires": {
+        "d3-time": "1 - 3"
+      }
+    },
+    "d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+    },
+    "d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "requires": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      }
+    },
+    "d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "requires": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      }
+    },
+    "delaunator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.0.tgz",
+      "integrity": "sha512-AyLvtyJdbv/U1GkiS6gUUzclRoAY4Gs75qkMygJJhU75LW4DNuSF2RMzpxs9jw9Oz1BobHjTdkG3zdP55VxAqw==",
+      "requires": {
+        "robust-predicates": "^3.0.0"
+      }
+    },
     "esbuild": {
       "version": "0.14.49",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.14.49.tgz",
@@ -758,6 +1976,19 @@
         "function-bind": "^1.1.1"
       }
     },
+    "iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      }
+    },
+    "internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="
+    },
     "is-core-module": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.9.0.tgz",
@@ -807,6 +2038,11 @@
         "supports-preserve-symlinks-flag": "^1.0.0"
       }
     },
+    "robust-predicates": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.1.tgz",
+      "integrity": "sha512-ndEIpszUHiG4HtDsQLeIuMvRsDnn8c8rYStabochtUeCvfuvNptb5TUbVD68LRAILPX7p9nqQGh4xJgn3EHS/g=="
+    },
     "rollup": {
       "version": "2.77.0",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.77.0.tgz",
@@ -815,6 +2051,16 @@
       "requires": {
         "fsevents": "~2.3.2"
       }
+    },
+    "rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "source-map-js": {
       "version": "1.0.2",

--- a/icicle/taejs/package.json
+++ b/icicle/taejs/package.json
@@ -9,7 +9,11 @@
     "preview": "vite preview"
   },
   "devDependencies": {
+    "@types/d3": "^7.4.0",
     "typescript": "^4.6.4",
     "vite": "^3.0.0"
+  },
+  "dependencies": {
+    "d3": "^7.6.1"
   }
 }

--- a/icicle/taejs/public/data.json
+++ b/icicle/taejs/public/data.json
@@ -1,0 +1,1036 @@
+{
+    "name": "project",
+    "children": [
+      {
+        "name": "packages",
+        "children": [
+          {
+            "name": "vue-server-renderer",
+            "children": [
+              {
+                "name": "build.dev.js",
+                "value": 4,
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 226,
+                    "deletions": 142,
+                    "count": 4
+                  }
+                }
+              },
+              {
+                "name": "basic.js",
+                "value": 2,
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 155,
+                    "deletions": 71,
+                    "count": 2
+                  }
+                }
+              },
+              {
+                "name": "build.prod.js",
+                "value": 2,
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 2,
+                    "deletions": 2,
+                    "count": 2
+                  }
+                }
+              },
+              {
+                "name": "package.json",
+                "value": 2,
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 2,
+                    "deletions": 2,
+                    "count": 2
+                  }
+                }
+              }
+            ],
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 385,
+                "deletions": 217,
+                "count": 10
+              }
+            }
+          },
+          {
+            "name": "weex-vue-framework/factory.js",
+            "value": 2
+          },
+          {
+            "name": "vue-template-compiler",
+            "children": [
+              {
+                "name": "README.md",
+                "value": 1,
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 3,
+                    "deletions": 3,
+                    "count": 1
+                  }
+                }
+              },
+              {
+                "name": "browser.js",
+                "value": 2,
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 49,
+                    "deletions": 19,
+                    "count": 2
+                  }
+                }
+              },
+              {
+                "name": "build.js",
+                "value": 2,
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 49,
+                    "deletions": 19,
+                    "count": 2
+                  }
+                }
+              },
+              {
+                "name": "package.json",
+                "value": 2,
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 2,
+                    "deletions": 2,
+                    "count": 2
+                  }
+                }
+              },
+              {
+                "name": "index.js",
+                "value": 1,
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 4,
+                    "deletions": 2,
+                    "count": 1
+                  }
+                }
+              }
+            ],
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 107,
+                "deletions": 45,
+                "count": 8
+              }
+            }
+          }
+        ],
+        "authors": {
+          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+            "insertions": 492,
+            "deletions": 262,
+            "count": 18
+          }
+        }
+      },
+      {
+        "name": "src",
+        "children": [
+          {
+            "name": "shared/util.js",
+            "value": 3
+          },
+          {
+            "name": "compiler",
+            "children": [
+              {
+                "name": "codeframe.js",
+                "value": 1,
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 7,
+                    "deletions": 5,
+                    "count": 1
+                  }
+                }
+              },
+              {
+                "name": "codegen",
+                "children": [
+                  {
+                    "name": "index.js",
+                    "value": 1,
+                    "authors": {
+                      "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                        "insertions": 29,
+                        "deletions": 6,
+                        "count": 1
+                      }
+                    }
+                  },
+                  {
+                    "name": "events.js",
+                    "value": 1,
+                    "authors": {
+                      "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                        "insertions": 1,
+                        "deletions": 1,
+                        "count": 1
+                      }
+                    }
+                  }
+                ],
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 30,
+                    "deletions": 7,
+                    "count": 2
+                  }
+                }
+              },
+              {
+                "name": "parser",
+                "children": [
+                  {
+                    "name": "html-parser.js",
+                    "value": 1,
+                    "authors": {
+                      "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                        "insertions": 3,
+                        "deletions": 3,
+                        "count": 1
+                      }
+                    }
+                  },
+                  {
+                    "name": "index.js",
+                    "value": 2,
+                    "authors": {
+                      "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                        "insertions": 4,
+                        "deletions": 3,
+                        "count": 2
+                      }
+                    }
+                  }
+                ],
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 7,
+                    "deletions": 6,
+                    "count": 3
+                  }
+                }
+              }
+            ],
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 44,
+                "deletions": 18,
+                "count": 6
+              }
+            }
+          },
+          {
+            "name": "core",
+            "children": [
+              {
+                "name": "instance",
+                "children": [
+                  {
+                    "name": "lifecycle.js",
+                    "value": 1,
+                    "authors": {
+                      "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                        "insertions": 5,
+                        "deletions": 2,
+                        "count": 1
+                      }
+                    }
+                  },
+                  {
+                    "name": "render-helpers",
+                    "children": [
+                      {
+                        "name": "bind-object-props.js",
+                        "value": 1,
+                        "authors": {
+                          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                            "insertions": 5,
+                            "deletions": 3,
+                            "count": 1
+                          }
+                        }
+                      },
+                      {
+                        "name": "resolve-scoped-slots.js",
+                        "value": 1,
+                        "authors": {
+                          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                            "insertions": 7,
+                            "deletions": 2,
+                            "count": 1
+                          }
+                        }
+                      }
+                    ],
+                    "authors": {
+                      "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                        "insertions": 12,
+                        "deletions": 5,
+                        "count": 2
+                      }
+                    }
+                  }
+                ],
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 17,
+                    "deletions": 7,
+                    "count": 3
+                  }
+                }
+              },
+              {
+                "name": "observer/scheduler.js",
+                "value": 2
+              },
+              {
+                "name": "util",
+                "children": [
+                  {
+                    "name": "error.js",
+                    "value": 2,
+                    "authors": {
+                      "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                        "insertions": 7,
+                        "deletions": 4,
+                        "count": 2
+                      }
+                    }
+                  },
+                  {
+                    "name": "lang.js",
+                    "value": 1,
+                    "authors": {
+                      "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                        "insertions": 2,
+                        "deletions": 2,
+                        "count": 1
+                      }
+                    }
+                  },
+                  {
+                    "name": "options.js",
+                    "value": 1,
+                    "authors": {
+                      "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                        "insertions": 2,
+                        "deletions": 2,
+                        "count": 1
+                      }
+                    }
+                  }
+                ],
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 11,
+                    "deletions": 8,
+                    "count": 4
+                  }
+                }
+              },
+              {
+                "name": "vdom/helpers",
+                "children": [
+                  {
+                    "name": "normalize-scoped-slots.js",
+                    "value": 2,
+                    "authors": {
+                      "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                        "insertions": 15,
+                        "deletions": 6,
+                        "count": 2
+                      }
+                    }
+                  },
+                  {
+                    "name": "resolve-async-component.js",
+                    "value": 2,
+                    "authors": {
+                      "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                        "insertions": 27,
+                        "deletions": 10,
+                        "count": 2
+                      }
+                    }
+                  }
+                ],
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 42,
+                    "deletions": 16,
+                    "count": 4
+                  }
+                }
+              }
+            ],
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 70,
+                "deletions": 31,
+                "count": 11
+              }
+            }
+          },
+          {
+            "name": "platforms/web/runtime/modules",
+            "children": [
+              {
+                "name": "dom-props.js",
+                "value": 2,
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 15,
+                    "deletions": 12,
+                    "count": 2
+                  }
+                }
+              },
+              {
+                "name": "events.js",
+                "value": 1,
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 4,
+                    "deletions": 2,
+                    "count": 1
+                  }
+                }
+              },
+              {
+                "name": "transition.js",
+                "value": 1,
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 1,
+                    "deletions": 1,
+                    "count": 1
+                  }
+                }
+              }
+            ],
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 20,
+                "deletions": 15,
+                "count": 4
+              }
+            }
+          },
+          {
+            "name": "server",
+            "children": [
+              {
+                "name": "write.js",
+                "value": 1,
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 1,
+                    "deletions": 1,
+                    "count": 1
+                  }
+                }
+              },
+              {
+                "name": "template-renderer/create-async-file-mapper.js",
+                "value": 1
+              }
+            ],
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 1,
+                "deletions": 1,
+                "count": 1
+              }
+            }
+          }
+        ],
+        "authors": {
+          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+            "insertions": 135,
+            "deletions": 65,
+            "count": 22
+          }
+        }
+      },
+      {
+        "name": "test",
+        "children": [
+          {
+            "name": "unit",
+            "children": [
+              {
+                "name": "util/loose-equal.spec.js",
+                "value": 3
+              },
+              {
+                "name": "features",
+                "children": [
+                  {
+                    "name": "component",
+                    "children": [
+                      {
+                        "name": "component-scoped-slot.spec.js",
+                        "value": 2,
+                        "authors": {
+                          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                            "insertions": 112,
+                            "deletions": 0,
+                            "count": 2
+                          }
+                        }
+                      },
+                      {
+                        "name": "component-async.spec.js",
+                        "value": 1,
+                        "authors": {
+                          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                            "insertions": 64,
+                            "deletions": 0,
+                            "count": 1
+                          }
+                        }
+                      }
+                    ],
+                    "authors": {
+                      "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                        "insertions": 176,
+                        "deletions": 0,
+                        "count": 3
+                      }
+                    }
+                  },
+                  {
+                    "name": "directives/bind.spec.js",
+                    "value": 1
+                  },
+                  {
+                    "name": "instance/methods-events.spec.js",
+                    "value": 1
+                  },
+                  {
+                    "name": "options/directives.spec.js",
+                    "value": 1
+                  },
+                  {
+                    "name": "transition/transition.spec.js",
+                    "value": 1
+                  }
+                ],
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 176,
+                    "deletions": 0,
+                    "count": 3
+                  }
+                }
+              },
+              {
+                "name": "modules",
+                "children": [
+                  {
+                    "name": "compiler",
+                    "children": [
+                      {
+                        "name": "codegen.spec.js",
+                        "value": 2,
+                        "authors": {
+                          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                            "insertions": 9,
+                            "deletions": 4,
+                            "count": 2
+                          }
+                        }
+                      },
+                      {
+                        "name": "compiler-options.spec.js",
+                        "value": 1,
+                        "authors": {
+                          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                            "insertions": 5,
+                            "deletions": 0,
+                            "count": 1
+                          }
+                        }
+                      },
+                      {
+                        "name": "parser.spec.js",
+                        "value": 1,
+                        "authors": {
+                          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                            "insertions": 44,
+                            "deletions": 5,
+                            "count": 1
+                          }
+                        }
+                      }
+                    ],
+                    "authors": {
+                      "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                        "insertions": 58,
+                        "deletions": 9,
+                        "count": 4
+                      }
+                    }
+                  },
+                  {
+                    "name": "util",
+                    "children": [
+                      {
+                        "name": "invoke-with-error-handling.spec.js",
+                        "value": 1,
+                        "authors": {
+                          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                            "insertions": 21,
+                            "deletions": 0,
+                            "count": 1
+                          }
+                        }
+                      },
+                      {
+                        "name": "{invoke-with-error-handling.spec.js => error.spec.js}",
+                        "value": 1,
+                        "authors": {
+                          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                            "insertions": 5,
+                            "deletions": 2,
+                            "count": 1
+                          }
+                        }
+                      }
+                    ],
+                    "authors": {
+                      "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                        "insertions": 26,
+                        "deletions": 2,
+                        "count": 2
+                      }
+                    }
+                  },
+                  {
+                    "name": "vdom",
+                    "children": [
+                      {
+                        "name": "create-component.spec.js",
+                        "value": 1,
+                        "authors": {
+                          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                            "insertions": 6,
+                            "deletions": 0,
+                            "count": 1
+                          }
+                        }
+                      },
+                      {
+                        "name": "patch/edge-cases.spec.js",
+                        "value": 1
+                      }
+                    ],
+                    "authors": {
+                      "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                        "insertions": 6,
+                        "deletions": 0,
+                        "count": 1
+                      }
+                    }
+                  },
+                  {
+                    "name": "observer/observer.spec.js",
+                    "value": 1
+                  }
+                ],
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 90,
+                    "deletions": 11,
+                    "count": 7
+                  }
+                }
+              }
+            ],
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 266,
+                "deletions": 11,
+                "count": 10
+              }
+            }
+          },
+          {
+            "name": "ssr/ssr-string.spec.js",
+            "value": 2
+          }
+        ],
+        "authors": {
+          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+            "insertions": 266,
+            "deletions": 11,
+            "count": 10
+          }
+        }
+      },
+      {
+        "name": ".github",
+        "children": [
+          {
+            "name": "CODE_OF_CONDUCT.md",
+            "value": 1,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 1,
+                "deletions": 1,
+                "count": 1
+              }
+            }
+          },
+          {
+            "name": "COMMIT_CONVENTION.md",
+            "value": 1,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 5,
+                "deletions": 5,
+                "count": 1
+              }
+            }
+          },
+          {
+            "name": "CONTRIBUTING.md",
+            "value": 1,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 5,
+                "deletions": 5,
+                "count": 1
+              }
+            }
+          }
+        ],
+        "authors": {
+          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+            "insertions": 11,
+            "deletions": 11,
+            "count": 3
+          }
+        }
+      },
+      {
+        "name": "BACKERS.md",
+        "value": 2,
+        "authors": {
+          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+            "insertions": 77,
+            "deletions": 83,
+            "count": 2
+          }
+        }
+      },
+      {
+        "name": "README.md",
+        "value": 2,
+        "authors": {
+          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+            "insertions": 24,
+            "deletions": 19,
+            "count": 2
+          }
+        }
+      },
+      {
+        "name": "benchmarks",
+        "children": [
+          {
+            "name": "ssr/README.md",
+            "value": 1
+          },
+          {
+            "name": "uptime/index.html",
+            "value": 1
+          }
+        ],
+        "authors": {}
+      },
+      {
+        "name": "dist",
+        "children": [
+          {
+            "name": "README.md",
+            "value": 1,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 1,
+                "deletions": 1,
+                "count": 1
+              }
+            }
+          },
+          {
+            "name": "vue.common.dev.js",
+            "value": 2,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 179,
+                "deletions": 90,
+                "count": 2
+              }
+            }
+          },
+          {
+            "name": "vue.common.prod.js",
+            "value": 2,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 4,
+                "deletions": 4,
+                "count": 2
+              }
+            }
+          },
+          {
+            "name": "vue.esm.browser.js",
+            "value": 2,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 177,
+                "deletions": 86,
+                "count": 2
+              }
+            }
+          },
+          {
+            "name": "vue.esm.browser.min.js",
+            "value": 2,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 4,
+                "deletions": 4,
+                "count": 2
+              }
+            }
+          },
+          {
+            "name": "vue.esm.js",
+            "value": 2,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 179,
+                "deletions": 90,
+                "count": 2
+              }
+            }
+          },
+          {
+            "name": "vue.js",
+            "value": 2,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 179,
+                "deletions": 90,
+                "count": 2
+              }
+            }
+          },
+          {
+            "name": "vue.min.js",
+            "value": 2,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 4,
+                "deletions": 4,
+                "count": 2
+              }
+            }
+          },
+          {
+            "name": "vue.runtime.common.dev.js",
+            "value": 2,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 131,
+                "deletions": 72,
+                "count": 2
+              }
+            }
+          },
+          {
+            "name": "vue.runtime.common.prod.js",
+            "value": 2,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 4,
+                "deletions": 4,
+                "count": 2
+              }
+            }
+          },
+          {
+            "name": "vue.runtime.esm.js",
+            "value": 2,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 131,
+                "deletions": 72,
+                "count": 2
+              }
+            }
+          },
+          {
+            "name": "vue.runtime.js",
+            "value": 2,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 131,
+                "deletions": 72,
+                "count": 2
+              }
+            }
+          },
+          {
+            "name": "vue.runtime.min.js",
+            "value": 2,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 4,
+                "deletions": 4,
+                "count": 2
+              }
+            }
+          }
+        ],
+        "authors": {
+          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+            "insertions": 1128,
+            "deletions": 593,
+            "count": 25
+          }
+        }
+      },
+      {
+        "name": "package.json",
+        "value": 2,
+        "authors": {
+          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+            "insertions": 2,
+            "deletions": 2,
+            "count": 2
+          }
+        }
+      },
+      {
+        "name": "types",
+        "children": [
+          {
+            "name": "options.d.ts",
+            "value": 2,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 3,
+                "deletions": 3,
+                "count": 2
+              }
+            }
+          },
+          {
+            "name": "test",
+            "children": [
+              {
+                "name": "options-test.ts",
+                "value": 2,
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 19,
+                    "deletions": 0,
+                    "count": 2
+                  }
+                }
+              },
+              {
+                "name": "vue-test.ts",
+                "value": 2,
+                "authors": {
+                  "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                    "insertions": 35,
+                    "deletions": 0,
+                    "count": 2
+                  }
+                }
+              }
+            ],
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 54,
+                "deletions": 0,
+                "count": 4
+              }
+            }
+          },
+          {
+            "name": "vnode.d.ts",
+            "value": 2,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 6,
+                "deletions": 2,
+                "count": 2
+              }
+            }
+          },
+          {
+            "name": "vue.d.ts",
+            "value": 1,
+            "authors": {
+              "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+                "insertions": 3,
+                "deletions": 3,
+                "count": 1
+              }
+            }
+          }
+        ],
+        "authors": {
+          "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+            "insertions": 66,
+            "deletions": 8,
+            "count": 9
+          }
+        }
+      },
+      {
+        "name": "examples/modal/index.html",
+        "value": 1
+      },
+      {
+        "name": "flow/vnode.js",
+        "value": 1
+      },
+      {
+        "name": "scripts/alias.js",
+        "value": 1
+      }
+    ],
+    "authors": {
+      "Jacob Müller <jacob.mueller.elz@gmail.com>": {
+        "insertions": 2201,
+        "deletions": 1054,
+        "count": 93
+      }
+    }
+  }

--- a/icicle/taejs/src/main.ts
+++ b/icicle/taejs/src/main.ts
@@ -1,1 +1,54 @@
 import './style.css';
+import * as d3 from 'd3';
+import { TFileData } from './types';
+
+const WIDTH = 600;
+const HEIGHT = 400;
+
+const getData = async (): Promise<TFileData> => {
+  const response = await fetch('/data.json');
+  return response.json();
+}
+
+// https://observablehq.com/@d3/icicle 참고
+const drawIcicleTree = async (data: TFileData) => {
+  const $container = d3.select('#icicle')
+    .attr('width', WIDTH)
+    .attr('height', HEIGHT);
+
+  // icicle tree를 위한 hierarchy 데이터 생성
+  // https://github.com/d3/d3-hierarchy/blob/v3.1.2/README.md#hierarchy
+  const hierachy = d3.hierarchy(data);
+
+  // hierarchy 데이터를 그리기전에 필수로 호출
+  // 트리를 순회하면서 leaf의 값을 상위로 끌어올림 (post order traversal)
+  // 호출 대상을 변형함(mutating function)  
+  // https://observablehq.com/@d3/visiting-a-d3-hierarchy#count
+  hierachy.count();
+
+  // githru FileIcicleSummary 따라서 value 내림차순 정렬
+  hierachy.sort((a, b) => (b.value ?? 0) - (a.value ?? 0));
+
+  // icicle tree 생성 
+  // https://github.com/d3/d3-hierarchy/blob/v3.1.2/README.md#partition
+  const partition = d3.partition<TFileData>()
+    .size([HEIGHT, WIDTH])(hierachy);
+
+  // 파티션 위치 설정
+  const cell = $container.selectAll('g')
+    .data(partition.descendants())
+    .join('g')
+      .attr('transform', d => `translate(${d.y0},${d.x0})`);
+
+  // 파티션 각 영역 그리기
+  cell.append('rect')
+    .attr('width', d => d.y1 - d.y0)
+    .attr('height', d => d.x1 - d.x0);
+}
+
+const main = async () => {
+  const data = await getData();
+  drawIcicleTree(data);
+}
+
+main();

--- a/icicle/taejs/src/main.ts
+++ b/icicle/taejs/src/main.ts
@@ -1,9 +1,19 @@
 import './style.css';
 import * as d3 from 'd3';
 import { TFileData } from './types';
+import { HierarchyRectangularNode } from 'd3';
 
 const WIDTH = 600;
 const HEIGHT = 400;
+const FONT_SIZE = 12;
+const COLOR_CODE = {
+  dir: '#ffcc80',
+  file: '#ffe082'
+}
+
+const getIsVisibleLabel = (d: HierarchyRectangularNode<TFileData>) => {
+  return (d.x1 - d.x0) > 16;
+}
 
 const getData = async (): Promise<TFileData> => {
   const response = await fetch('/data.json');
@@ -32,7 +42,8 @@ const drawIcicleTree = async (data: TFileData) => {
   // icicle tree 생성 
   // https://github.com/d3/d3-hierarchy/blob/v3.1.2/README.md#partition
   const partition = d3.partition<TFileData>()
-    .size([HEIGHT, WIDTH])(hierachy);
+    .size([HEIGHT, WIDTH])
+    .padding(1)(hierachy);
 
   // 파티션 위치 설정
   const cell = $container.selectAll('g')
@@ -43,7 +54,16 @@ const drawIcicleTree = async (data: TFileData) => {
   // 파티션 각 영역 그리기
   cell.append('rect')
     .attr('width', d => d.y1 - d.y0)
-    .attr('height', d => d.x1 - d.x0);
+    .attr('height', d => d.x1 - d.x0)
+    // 원본데이터에 value가 없는 경우 디렉토리로 판단
+    .style('fill', d => COLOR_CODE[d.data.value !== undefined ? 'file' : 'dir']);
+
+  cell.append('text')
+    .attr('x', 4)
+    .attr('y', d => Math.min(13, (d.x1 - d.x0) / 2))
+    .style('font-size', FONT_SIZE)
+    .attr('fill-opacity', d => getIsVisibleLabel(d) ? 1 : 0)
+    .text(d => `${d.data.name}/ ${d.value}`);
 }
 
 const main = async () => {

--- a/icicle/taejs/src/main.ts
+++ b/icicle/taejs/src/main.ts
@@ -6,6 +6,8 @@ import { HierarchyRectangularNode } from 'd3';
 const WIDTH = 600;
 const HEIGHT = 400;
 const FONT_SIZE = 12;
+const MAX_DEPTH = 4;
+const SINGLE_RECT_WIDTH = WIDTH / MAX_DEPTH;
 const COLOR_CODE = {
   dir: '#ffcc80',
   file: '#ffe082'
@@ -42,14 +44,14 @@ const drawIcicleTree = async (data: TFileData) => {
   // icicle tree 생성 
   // https://github.com/d3/d3-hierarchy/blob/v3.1.2/README.md#partition
   const partition = d3.partition<TFileData>()
-    .size([HEIGHT, WIDTH])
+    .size([HEIGHT, (hierachy.height + 1) * SINGLE_RECT_WIDTH])
     .padding(1)(hierachy);
 
   // 파티션 위치 설정
   const cell = $container.selectAll('g')
     .data(partition.descendants())
     .join('g')
-      .attr('transform', d => `translate(${d.y0},${d.x0})`);
+      .attr('transform', d => `translate(${d.y0 - SINGLE_RECT_WIDTH},${d.x0})`);
 
   // 파티션 각 영역 그리기
   cell.append('rect')

--- a/icicle/taejs/src/types.ts
+++ b/icicle/taejs/src/types.ts
@@ -1,0 +1,10 @@
+export type TFileData = {
+  name: string; // 파일 혹은 디렉토리 이름
+  value?: number; // 변경된 라인 수 
+  authors: Record<string, {
+      insertion: number;
+      deletions: number;
+      count: number;
+  }>
+  children: TFileData[],
+}


### PR DESCRIPTION
icicle 과제입니다.
![image](https://user-images.githubusercontent.com/41318449/180648351-419de49b-d22d-49ae-89d7-524fb8535987.png)


## PR 설명
![image](https://user-images.githubusercontent.com/41318449/180648289-8c64eda1-b392-4800-870e-f2f9ff23ef8c.png)
이번 PR에서는 mock 데이터 추가 및 icicle 구현을 진행했습니다.

### **githru 파일 변경 데이터 복사** (https://github.com/githru/2022-tutorial/commit/a0844e7b13244f15ced7bef8cb3945c6be05f518) 

icicle tree에서 사용할 파일 
vue CSM 중 한가지를 임의로 선정해서 githuru - FileIcicleSummary.js >line 57의 `fileAnalyzer.getFileStructure()` 결과값을 복사해왔습니다.
바로 d3 hierarchy로 사용할수 있는 형태입니다.
이 파일은 다른곳에 올려두고 공통으로 사용할 수도 있을것 같기는 하네요 

githru 에서는 이렇게 보입니다.
![image](https://user-images.githubusercontent.com/41318449/180648461-57cab73a-d00f-4f85-afa3-552ecc24af71.png)

 
### **파일 변경 line 수 기반 icicle tree 그리기** https://github.com/githru/2022-tutorial/commit/fd327a01ee886f3e8662f8f9a45837696b227790

위에서 추가한 json 파일을 가져오고 d3의 partition을 사용해 icicle tree 기본 렌더링을 진행했습니다. 저도 처음 학습하는 내용들이고 리뷰할때도 이해가 잘 안될수도 있을것 같아서 각 라인에 주석을 추가해두었습니다.

### **icicle tree 가시성 개선** https://github.com/githru/2022-tutorial/commit/7948491b1971310edf4f924ce207027635b32103
Githuru의 FileIcicleSummary.js 참고해서 icicle tree 가시성 개선을 진행했습니다.

  - 각 영역 패딩 추가
  - 영역 색상 구분 추가 (파일/디렉토리별)
  - 영역 별 텍스트 추가
  - 영역 높이에 따른 텍스트 노출 여부 설정 (getIsVisibleLabel 적용)

### **주요기능 개발 - depth 구현, root 영역 미노출** https://github.com/githru/2022-tutorial/commit/4e59e03c43a6a4c97d79a8b71df61d183a458668
맨 위 과제를 보시면 depth 4라는 요구사항이 있어서 구현했습니다.
AS IS: 데이터 전체 depth가 가로 600px에 맞춰서 렌더 - 10개의 depth인 경우 각 영역이 60px
TO BE: 데이터 전체 depth중 4개까지만 렌더

D3에서는 관련 옵션을 제공하지 않아서 요 내용을 어떻게 구현할지 고민이 됐었는데 githru에 답이 있었습니다. [링크](https://github.com/githru/githru/blob/b479984a3081e4e6e389179b86a6997db984d5a3/frontend/src/components/FileIcicleSummary.js#L19-L21)

width 설정 로직이 다음과 같이 되어있습니다. `((root.height + 1) * width / pageNum)`
root.height : root를 제외한 하위 depth
width: 전체 (여기서는 600px)
pageNum: 제한할 depth (여기서는 4)

각 영역을 width / pageNum 사이즈만큼 늘리면 어차피 svg영역이 600px라서 넘어간 부분들은 보이지 않으니 사용자에게는 현재 4개의 depth만 노출되는것처럼 보여지게 됩니다. 


root 영역 미노출은 요구사항에는 없었는데 githru에 적용되어있는 부분이라 같이 적용했습니다. 아래 이미지처럼 최상위 영역은 숨겨져있는데요 이 부분도 구현이 간단합니다. translate 값에 width / pageNum 사이즈(한개의 영역)만큼 빼면 최상위 영역이 숨겨지게 됩니다. [링크](https://github.com/githru/githru/blob/b479984a3081e4e6e389179b86a6997db984d5a3/frontend/src/components/FileIcicleSummary.js#L101-L102)
![image](https://user-images.githubusercontent.com/41318449/180649150-2af661da-cb0c-4ef4-b3c9-5ba09463ce4f.png)




---

## 테스트 방법
README.md 내용대로 npm run dev 혹은 npm run build && npm run preview 실행하시면 실제 테스트가 가능합니다.

