### PR TITLE
Init Components

### DIFF
--- a/linechart/jin-pro/src/App.css
+++ b/linechart/jin-pro/src/App.css
@@ -1,3 +1,0 @@
-.App {
-  text-align: center;
-}

--- a/linechart/jin-pro/src/App.tsx
+++ b/linechart/jin-pro/src/App.tsx
@@ -1,10 +1,14 @@
-import React from 'react';
-import './App.css';
+import React from "react";
+import { Chart } from "./Chart";
 
 function App() {
   return (
     <div className="App">
-      
+      <Chart>
+        <Chart.Graph />
+        <Chart.XAxis />
+        <Chart.YAxis />
+      </Chart>
     </div>
   );
 }

--- a/linechart/jin-pro/src/Chart/Chart.hook.tsx
+++ b/linechart/jin-pro/src/Chart/Chart.hook.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+
+const l = 50;
+const data = Array.from({ length: l }, (x) => Math.round(Math.random() * 100));
+
+export const useGetChartDatas = () => {
+  const tempData = data;
+
+  return tempData;
+};
+
+export const ChartDataContext = React.createContext(data);

--- a/linechart/jin-pro/src/Chart/index.tsx
+++ b/linechart/jin-pro/src/Chart/index.tsx
@@ -1,0 +1,22 @@
+import { ReactNode } from "react";
+import { Graph, XAxis, YAxis } from "../Component";
+import { ChartDataContext, useGetChartDatas } from "./Chart.hook";
+
+type Props = {
+  Graph: React.FC;
+  XAxis: React.FC;
+  YAxis: React.FC;
+} & React.FC<{ children: ReactNode[] }>;
+
+export const Chart: Props = ({ children }) => {
+  const value = useGetChartDatas();
+  return (
+    <ChartDataContext.Provider value={value}>
+      {children}
+    </ChartDataContext.Provider>
+  );
+};
+
+Chart.Graph = Graph;
+Chart.XAxis = XAxis;
+Chart.YAxis = YAxis;

--- a/linechart/jin-pro/src/Component/Graph/Graph.tsx
+++ b/linechart/jin-pro/src/Component/Graph/Graph.tsx
@@ -1,0 +1,3 @@
+export const Graph: React.FC = () => {
+  return <div>그래프</div>;
+};

--- a/linechart/jin-pro/src/Component/Graph/Graph.tsx
+++ b/linechart/jin-pro/src/Component/Graph/Graph.tsx
@@ -1,3 +1,7 @@
+import { useContext } from "react";
+import { ChartDataContext } from "../../Chart/Chart.hook";
+
 export const Graph: React.FC = () => {
+  const data = useContext(ChartDataContext);
   return <div>그래프</div>;
 };

--- a/linechart/jin-pro/src/Component/XAxis/XAxis.tsx
+++ b/linechart/jin-pro/src/Component/XAxis/XAxis.tsx
@@ -1,3 +1,7 @@
+import { useContext } from "react";
+import { ChartDataContext } from "../../Chart/Chart.hook";
+
 export const XAxis: React.FC = () => {
+  const data = useContext(ChartDataContext);
   return <div>X축</div>;
 };

--- a/linechart/jin-pro/src/Component/XAxis/XAxis.tsx
+++ b/linechart/jin-pro/src/Component/XAxis/XAxis.tsx
@@ -1,0 +1,3 @@
+export const XAxis: React.FC = () => {
+  return <div>X축</div>;
+};

--- a/linechart/jin-pro/src/Component/YAxis/YAxis.tsx
+++ b/linechart/jin-pro/src/Component/YAxis/YAxis.tsx
@@ -1,3 +1,7 @@
+import { useContext } from "react";
+import { ChartDataContext } from "../../Chart/Chart.hook";
+
 export const YAxis: React.FC = () => {
+  const data = useContext(ChartDataContext);
   return <div>Y축</div>;
 };

--- a/linechart/jin-pro/src/Component/YAxis/YAxis.tsx
+++ b/linechart/jin-pro/src/Component/YAxis/YAxis.tsx
@@ -1,0 +1,3 @@
+export const YAxis: React.FC = () => {
+  return <div>Y축</div>;
+};

--- a/linechart/jin-pro/src/Component/index.tsx
+++ b/linechart/jin-pro/src/Component/index.tsx
@@ -1,0 +1,3 @@
+export * from "./XAxis/XAxis";
+export * from "./YAxis/YAxis";
+export * from "./Graph/Graph";


### PR DESCRIPTION
Zoomable Area Chart를 만들어 보려합니다!

Component를
- x 축
- y 축
- graph
로 나누어 3개의 컴포넌트를 
Chart라는 Main Component아래 종속시켜 컴포넌트간 응집도를 높여보려고 했습니다!

상태는 크게 나뉠게 없을 것 같고, props Drilling을 사용해도 되지만, 딱히 재사용성도 보이지 않고
컴포넌트의 응집도를 높여보고자 context를 사용해서  Chart라는 컴포넌트를 만들었습니다.

타입도 지정한게 없고 d3를 사용하기 직전이라 사부작 구현하겠슴다!