### PR TITLE
feat: line chart 구현

### DIFF
--- a/linechart/ag502/src/App.tsx
+++ b/linechart/ag502/src/App.tsx
@@ -6,10 +6,12 @@ import { AppleStockColumnType } from './types';
 // @ts-ignore
 import AppleStockCSV from './assets/data/appleStock.csv';
 
-const lengthInfo = {}
+const lengthInfo = {};
 
 function App() {
-    const [appleStockData, setAppleStockData] = useState<d3.DSVRowArray<AppleStockColumnType> | never[]>([]);
+    const [appleStockData, setAppleStockData] = useState<
+        d3.DSVRowString<AppleStockColumnType>[] | d3.DSVRowArray<AppleStockColumnType>
+    >([]);
 
     const fetchAppleStockData = useCallback(async () => {
         try {

--- a/linechart/ag502/src/App.tsx
+++ b/linechart/ag502/src/App.tsx
@@ -8,8 +8,12 @@ import AppleStockCSV from './assets/data/appleStock.csv';
 
 function App() {
     const [appleStockData, setAppleStockData] = useState<AppleStockDataType>([]);
+    const [numOfRows, setNumOfRows] = useState<number[]>([]);
     const [xValues, setXValues] = useState<Date[]>([]);
     const [yValues, setYValues] = useState<number[]>([]);
+    const [defined, setDefined] = useState<boolean[]>([]);
+    const [xDomain, setXDomain] = useState<Date[]>([]);
+    const [yDomain, setYDomain] = useState<number[]>([]);
 
     const fetchAppleStockData = useCallback(async () => {
         try {
@@ -33,8 +37,21 @@ function App() {
     useEffect(() => {
         if (appleStockData.columns) {
             const [xAxis, yAxis] = appleStockData.columns;
-            setXValues(d3.map(appleStockData, (x) => x[xAxis] as Date));
-            setYValues(d3.map(appleStockData, (y) => y[yAxis] as number));
+
+            const curXValues = d3.map(appleStockData, (x) => x[xAxis] as Date);
+            const curYValues = d3.map(appleStockData, (y) => y[yAxis] as number);
+            const curNumOfRows = d3.range(curXValues.length);
+            const curDefined = d3.map(
+                appleStockData,
+                (_, i) => !Number.isNaN(curXValues[i]) && !Number.isNaN(curYValues[i]),
+            );
+
+            setXValues(curXValues);
+            setYValues(curYValues);
+            setNumOfRows(curNumOfRows);
+            setDefined(curDefined);
+            setXDomain(d3.extent(curXValues) as Date[]);
+            setYDomain([0, d3.max(curYValues) as number]);
         }
     }, [appleStockData]);
 

--- a/linechart/ag502/src/App.tsx
+++ b/linechart/ag502/src/App.tsx
@@ -90,6 +90,7 @@ function App() {
         if (xDomain.length && yDomain.length && numOfRows.length) {
             // @ts-ignore
             const curPath = generateLine(numOfRows);
+
             if (curPath) {
                 setPath(curPath);
             }
@@ -103,8 +104,38 @@ function App() {
                 height={positionInfo.height}
                 viewBox={`0, 0, ${positionInfo.width}, ${positionInfo.height}`}
             >
+                <g transform={`translate(0, ${positionInfo.height - positionInfo.marginBottom})`}>
+                    {getXScale.ticks().map((tickValues) => (
+                        <g
+                            key={String(tickValues)}
+                            transform={`translate(${getXScale(tickValues)}, 0)`}
+                            textAnchor="middle"
+                        >
+                            <line y2={positionInfo.width / 80} stroke="green" />
+                            <text y={positionInfo.width / 80} dominantBaseline="hanging">
+                                {tickValues.getFullYear()}
+                            </text>
+                        </g>
+                    ))}
+                </g>
                 <g />
-                <g />
+                <g>
+                    {getYScale.ticks().map((tickValues) => (
+                        <g
+                            key={tickValues}
+                            transform={`translate(0,${getYScale(tickValues)})`}
+                            textAnchor="middle"
+                            dominantBaseline="middle"
+                        >
+                            <line
+                                x1={positionInfo.marginLeft}
+                                x2={positionInfo.width - positionInfo.marginRight}
+                                stroke="green"
+                            />
+                            <text dx={positionInfo.marginLeft - 20}>{tickValues}</text>
+                        </g>
+                    ))}
+                </g>
                 <path fill="none" stroke="red" d={path} />
             </svg>
         </div>

--- a/linechart/ag502/src/App.tsx
+++ b/linechart/ag502/src/App.tsx
@@ -1,21 +1,25 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import * as d3 from 'd3';
 
-import { AppleStockColumnType } from './types';
+import { AppleStockDataType, AppleStockColumnType } from './types';
 
 // @ts-ignore
 import AppleStockCSV from './assets/data/appleStock.csv';
 
-const lengthInfo = {};
-
 function App() {
-    const [appleStockData, setAppleStockData] = useState<
-        d3.DSVRowString<AppleStockColumnType>[] | d3.DSVRowArray<AppleStockColumnType>
-    >([]);
+    const [appleStockData, setAppleStockData] = useState<AppleStockDataType>([]);
+    const [xValues, setXValues] = useState<Date[]>([]);
+    const [yValues, setYValues] = useState<number[]>([]);
 
     const fetchAppleStockData = useCallback(async () => {
         try {
-            const data: d3.DSVRowArray<AppleStockColumnType> = await d3.csv(AppleStockCSV);
+            const data: d3.DSVParsedArray<AppleStockColumnType> = await d3.csv(
+                AppleStockCSV,
+                (row: d3.DSVRowString<keyof AppleStockColumnType>) => ({
+                    date: new Date(row.date ? row.date : ''),
+                    close: Number(row.close),
+                }),
+            );
             setAppleStockData(data);
         } catch (error) {
             setAppleStockData([]);
@@ -26,9 +30,19 @@ function App() {
         fetchAppleStockData();
     }, []);
 
+    useEffect(() => {
+        if (appleStockData.columns) {
+            const [xAxis, yAxis] = appleStockData.columns;
+            setXValues(d3.map(appleStockData, (x) => x[xAxis] as Date));
+            setYValues(d3.map(appleStockData, (y) => y[yAxis] as number));
+        }
+    }, [appleStockData]);
+
     return (
         <div className="App">
-            <svg />
+            <svg>
+                <path />
+            </svg>
         </div>
     );
 }

--- a/linechart/ag502/src/types.ts
+++ b/linechart/ag502/src/types.ts
@@ -1,7 +1,8 @@
-import { DSVRowString } from 'd3';
+interface AppleStockColumnType {
+    date: Date;
+    close: number;
+}
 
-type AppleStockColumnType = 'date' | 'close';
-
-type AppleStockDataType = DSVRowString<AppleStockColumnType>[] & { columns?: AppleStockColumnType[] };
+type AppleStockDataType = AppleStockColumnType[] & { columns?: Array<keyof AppleStockColumnType> };
 
 export type { AppleStockDataType, AppleStockColumnType };

--- a/linechart/ag502/src/types.ts
+++ b/linechart/ag502/src/types.ts
@@ -1,5 +1,7 @@
-type AppleStockDataType = { data: string; value: number }[];
+import { DSVRowString } from 'd3';
 
 type AppleStockColumnType = 'date' | 'close';
+
+type AppleStockDataType = DSVRowString<AppleStockColumnType>[] & { columns?: AppleStockColumnType[] };
 
 export type { AppleStockDataType, AppleStockColumnType };


### PR DESCRIPTION
# Content
<div align=center>
<img src="https://user-images.githubusercontent.com/35404137/181905674-f5d18385-3472-45b3-a543-063c61a902a5.png" />
</div>

# 수정할 부분

- [ ] svg가 익숙하지 않아 위치지정하는 부분의 값이 하드코딩 되어있습니다
- [ ] line chart의 데이터 파싱 및 눈금 간격을 지정하는 로직을 `custom hook`으로 분리할 예정입니다
