### PR TITLE
Line Chart => Chart Graph 그리기

### DIFF
--- a/linechart/jin-pro/src/App.tsx
+++ b/linechart/jin-pro/src/App.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Chart } from "./Chart";
 
 function App() {
@@ -6,8 +5,8 @@ function App() {
     <div className="App">
       <Chart>
         <Chart.Graph />
-        <Chart.XAxis />
-        <Chart.YAxis />
+        {/* <Chart.XAxis />
+        <Chart.YAxis /> */}
       </Chart>
     </div>
   );

--- a/linechart/jin-pro/src/Chart/Chart.hook.tsx
+++ b/linechart/jin-pro/src/Chart/Chart.hook.tsx
@@ -1,12 +1,59 @@
-import React from "react";
+import React, { useMemo, useEffect, useRef, useState } from "react";
+import { scaleLinear, line, curveCardinal, ScaleLinear, Line } from "d3";
 
 const l = 50;
 const data = Array.from({ length: l }, (x) => Math.round(Math.random() * 100));
 
-export const useGetChartDatas = () => {
+export const useGetChartDatas = (): ChartDataContextType => {
+  const svgRef = useRef<SVGSVGElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const [{ width, height }, setSize] = useState({
+    width: 0,
+    height: 0,
+  });
   const tempData = data;
 
-  return tempData;
+  const xScale: ScaleLinear<number, number, never> = useMemo(
+    () =>
+      scaleLinear()
+        .domain([0, data.length - 1])
+        .range([10, width - 10]),
+    [data, width]
+  );
+
+  const yScale: ScaleLinear<number, number, never> = useMemo(
+    () =>
+      scaleLinear()
+        .domain([0, Math.max(...data)])
+        .range([height - 10, 10]),
+    [height, data]
+  );
+
+  const lineGenerator: Line<[number, number]> = useMemo(
+    () =>
+      line()
+        .x((d, index) => xScale(index))
+        .y((d) => yScale(d[0]))
+        .curve(curveCardinal),
+    [xScale, yScale]
+  );
+
+  useEffect(() => {
+    if (!wrapperRef?.current) return;
+    const { width, height } = wrapperRef.current?.getBoundingClientRect()!;
+    setSize({ width, height });
+  }, [wrapperRef]);
+
+  return { svgRef, wrapperRef, xScale, yScale, lineGenerator, tempData };
 };
 
-export const ChartDataContext = React.createContext(data);
+export type ChartDataContextType = {
+  svgRef: React.RefObject<SVGSVGElement>;
+  wrapperRef: React.RefObject<HTMLDivElement>;
+  xScale: ScaleLinear<number, number, never>;
+  yScale: ScaleLinear<number, number, never>;
+  lineGenerator: Line<[number, number]>;
+  tempData: number[];
+};
+export const ChartDataContext =
+  React.createContext<ChartDataContextType | null>(null);

--- a/linechart/jin-pro/src/Chart/index.tsx
+++ b/linechart/jin-pro/src/Chart/index.tsx
@@ -6,13 +6,16 @@ type Props = {
   Graph: React.FC;
   XAxis: React.FC;
   YAxis: React.FC;
-} & React.FC<{ children: ReactNode[] }>;
+} & React.FC<{ children: ReactNode }>;
 
 export const Chart: Props = ({ children }) => {
   const value = useGetChartDatas();
+  const { wrapperRef, svgRef } = value;
   return (
     <ChartDataContext.Provider value={value}>
-      {children}
+      <div ref={wrapperRef} style={{ marginBottom: "2rem" }}>
+        <svg ref={svgRef}>{children}</svg>
+      </div>
     </ChartDataContext.Provider>
   );
 };

--- a/linechart/jin-pro/src/Component/Graph/Graph.tsx
+++ b/linechart/jin-pro/src/Component/Graph/Graph.tsx
@@ -1,7 +1,32 @@
+import { select } from "d3";
 import { useContext } from "react";
 import { ChartDataContext } from "../../Chart/Chart.hook";
 
 export const Graph: React.FC = () => {
-  const data = useContext(ChartDataContext);
-  return <div>그래프</div>;
+  const value = useContext(ChartDataContext);
+  if (value === null) return null;
+  const { svgRef, tempData, lineGenerator, xScale, yScale } = value;
+  const svg = select(svgRef.current);
+  const svgContent = svg.select(".content");
+  svgContent
+    .selectAll(".myLine")
+    .data([tempData])
+    .join("path")
+    .attr("class", "myLine")
+    .attr("stroke", "black")
+    .attr("fill", "none")
+    .attr("d", (d) => lineGenerator(d.map((data) => [data, data])));
+
+  svgContent
+    .selectAll(".myDot")
+    .data(tempData)
+    .join("circle")
+    .attr("class", "myDot")
+    .attr("stroke", "black")
+    .attr("r", 4)
+    .attr("fill", "orange")
+    .attr("cx", (v, index) => xScale(index))
+    .attr("cy", yScale);
+
+  return <g className="content"></g>;
 };


### PR DESCRIPTION
<img width="337" alt="스크린샷 2022-08-04 오전 2 02 28" src="https://user-images.githubusercontent.com/70205497/182667139-c0d324af-e430-49e1-9040-2d0d08b35c5c.png">

data를 랜덤으로 만들어, 
graph를 그려주는 작업을 했습니다!

컴포넌트의 의존성을 높이기 위해

Chart 컨테이너 아래에
Graph,
X축
Y축을

종속 시켜
Chart.Graph
Chart.XAxis
Chart.YAxis
컴포넌트를 렌더링 시켜줍니다.

각 컴포넌트에서 필요한 데이터는 context를 사용하여 props drilling를 사용하지 않고 바로 데이터를 가져와 렌더링 시켜주도록 작업하였습니다.

해당 PR에는 Graph 작업만 진행하였습니다.

---

컴포넌트로 분리하기 위해 서칭을 하다가 
기본적인 코드 골격은 @pshdev1030 님의 코드를 참고하였습니다.
